### PR TITLE
PR for Issue #1: Rename Delete Blog Popup Title

### DIFF
--- a/frontend/src/components/Blogs/Blogs.jsx
+++ b/frontend/src/components/Blogs/Blogs.jsx
@@ -362,7 +362,7 @@ const Blogs = () => {
 
         {showConfirmDelete && (
           <ConfirmModal
-            message="Do you want to delete this JOB?"
+            message="Do you want to delete this Blog?"
             onConfirm={handleDeleteConfirm}
             onCancel={() => {
               setShowConfirmDelete(false);


### PR DESCRIPTION
### 🛠 What’s Fixed
- Updated the title of the delete blog confirmation popup
- It was incorrectly showing "Job" instead of "Delete Blog"

### ✅ Changes
- Corrected the modal heading string for delete blog
- Ensured it reflects accurate action context

### 🔗 Related Issue
Closes #3
